### PR TITLE
:bug: Fix login error message

### DIFF
--- a/src/scenes/Auth/Login.jsx
+++ b/src/scenes/Auth/Login.jsx
@@ -18,7 +18,10 @@ const Login = ({ history, location }) => {
         // eslint-disable-next-line
         console.log(err)
         auth.logout() // Remove session for clean login
-        history.push({ pathname: '/auth/login', state: { error: err } })
+        history.push({
+          pathname: '/auth/login',
+          state: err.error === 'login_required' ? null : { error: err }
+        })
       })
     return <Loading text="Authenticating..." />
   }


### PR DESCRIPTION
Auth0 limits the renewal of passed token to around 2 days. After that, login is required.

In this case, we shouldn't show an error.

Fixes #66 