### PR TITLE
:bug: Fix sources that should not have been updated

### DIFF
--- a/server/src/answer/sources.js
+++ b/server/src/answer/sources.js
@@ -51,8 +51,14 @@ const updateSources = async (graphcool, answer) => {
   const oldSources = await getSources(graphcool, answer)
 
   const sourcesToAdd = _.differenceBy(newSources, oldSources, 'id')
-  const sourcesToUpdate = _.differenceBy(newSources, sourcesToAdd)
+  let sourcesToUpdate = _.differenceBy(newSources, sourcesToAdd)
   const sourcesToDelete = _.differenceBy(oldSources, newSources, 'id')
+
+  // Only update sources that were edited
+  sourcesToUpdate = sourcesToUpdate.filter(source => {
+    const oldSource = _.find(oldSources, { id: source.id })
+    return source.label !== oldSource.label || source.url !== oldSource.url
+  })
 
   const mutationsToAdd = sourcesToAdd.map(source => {
     return graphcool.request(addSourceQuery, {


### PR DESCRIPTION
Every sources was either added, updated or deleted. This had no impact until history came along. Now this shows: "edited question and updated X sources" even when the user doesn't change any sources.

This PR fixes this in order to only update a source when needed.