### PR TITLE
:memo: Document a missing step in the migration

### DIFF
--- a/server/prisma/migration_graphcool/README.md
+++ b/server/prisma/migration_graphcool/README.md
@@ -1,5 +1,12 @@
 # Migration from Graphcool to Prisma
 
+## Issues:
+
+The flags "unanswered" were not stored in the DB in graphcool, but they are now stored in Prisma.
+This script forgot to add theses flags into Prisma. (See issue #96)
+
+## Steps:
+
 - Place your `datamodel.graphql` and `prisma.yml` in this folder
 - Set the correct URL and TOKEN in `export.sh`
 - Set the correct URL in `prisma.yml`

--- a/server/prisma/resync_algolia/README.md
+++ b/server/prisma/resync_algolia/README.md
@@ -9,5 +9,5 @@ PRISMA_URL=the_url_with_service prisma export
 - Manually unzip the export into `data/`
 
 ```bash
-ALGOLIA_APP_ID=... ALGOLIA_API_KEY_ALL=... ALGOLIA_INDEX=...  node index.js
+ALGOLIA_APP_ID=... ALGOLIA_API_KEY_ADMIN=... ALGOLIA_INDEX=...  node index.js
 ```

--- a/server/prisma/resync_algolia/index.js
+++ b/server/prisma/resync_algolia/index.js
@@ -2,14 +2,14 @@ const fs = require('fs')
 
 const algoliasearch = require('algoliasearch')
 
-const { ALGOLIA_APP_ID, ALGOLIA_API_KEY_ALL, ALGOLIA_INDEX } = process.env
+const { ALGOLIA_APP_ID, ALGOLIA_API_KEY_ADMIN, ALGOLIA_INDEX } = process.env
 
-if (!ALGOLIA_APP_ID || !ALGOLIA_API_KEY_ALL || !ALGOLIA_INDEX) {
+if (!ALGOLIA_APP_ID || !ALGOLIA_API_KEY_ADMIN || !ALGOLIA_INDEX) {
   console.error('Algolia is absent from the environment variables')
   return
 }
 
-const client = algoliasearch(ALGOLIA_APP_ID, ALGOLIA_API_KEY_ALL)
+const client = algoliasearch(ALGOLIA_APP_ID, ALGOLIA_API_KEY_ADMIN)
 
 const index = client.initIndex(ALGOLIA_INDEX)
 
@@ -31,9 +31,9 @@ const writeJson = path => data =>
 
 const readAllFiles = () => {
   const files = [
-    readJson('./backup/lists/000001.json'),
-    readJson('./backup/nodes/000001.json'),
-    readJson('./backup/relations/000001.json')
+    readJson('./data/lists/000001.json'),
+    readJson('./data/nodes/000001.json'),
+    readJson('./data/relations/000001.json')
   ]
 
   return Promise.all(files)

--- a/server/src/resolvers/answer.js
+++ b/server/src/resolvers/answer.js
@@ -42,14 +42,9 @@ module.exports = {
         `
       )
 
-      if (answer.node.flags.length > 0) {
-        // For questions before the migration,
-        // the "unanswered" flag wasn't present in the db.
-        // So we need to test its presence before deleting it
-        await ctx.prisma.mutation.deleteFlag({
-          where: { id: answer.node.flags[0].id }
-        })
-      }
+      await ctx.prisma.mutation.deleteFlag({
+        where: { id: answer.node.flags[0].id }
+      })
 
       await history.push(ctx, {
         action: 'CREATED',

--- a/server/src/resolvers/answer.js
+++ b/server/src/resolvers/answer.js
@@ -42,9 +42,14 @@ module.exports = {
         `
       )
 
-      await ctx.prisma.mutation.deleteFlag({
-        where: { id: answer.node.flags[0].id }
-      })
+      if (answer.node.flags.length > 0) {
+        // For questions before the migration,
+        // the "unanswered" flag wasn't present in the db.
+        // So we need to test its presence before deleting it
+        await ctx.prisma.mutation.deleteFlag({
+          where: { id: answer.node.flags[0].id }
+        })
+      }
 
       await history.push(ctx, {
         action: 'CREATED',


### PR DESCRIPTION
The "unanswered" flags were not stored into the DB in graphcool, but implied by the absence of answer. But they are now stored in Prisma. 

The migration script forgot to create these flags in the new DB for previously created questions.

Issue #96 encountered a bug because the graphql resolver assumed there was a "unanswered" flag in the DB.

This has been fixed in the production database. And this PR add a notes in the readme of the migration script.