### PR TITLE
:children_crossing: Protect concurrent creation of an answer

### DIFF
--- a/src/components/AlertStack/Alert.jsx
+++ b/src/components/AlertStack/Alert.jsx
@@ -11,7 +11,10 @@ class Alert extends Component {
 
   componentDidMount() {
     setTimeout(() => this.context.showAlert(this.props.alert), 0)
-    setTimeout(() => this.context.closeAlert(this.props.alert), 5000)
+    setTimeout(
+      () => this.context.closeAlert(this.props.alert),
+      this.props.alert.type === 'success' ? 5000 : 7000
+    )
   }
 
   render() {


### PR DESCRIPTION
Partially covers #127 

If multiple users attempts to create an answer (aka: answer for the first time) a question, the subsequent users will now see an error alert. They won't lose what they wrote.