### PR TITLE
:bug: fix prisma scripts not actually running commands

### DIFF
--- a/server/scripts/helpers.js
+++ b/server/scripts/helpers.js
@@ -81,9 +81,7 @@ const queryService = (name, stage, gql) => {
 
 // Implicit env required: PRISMA_URL, PRISMA_MANAGEMENT_API_SECRET
 const queryManagement = gql => {
-  const token = generateManagementToken(
-    process.env.PRISMA_MANAGEMENT_API_SECRET
-  )
+  const token = generateManagementToken(process.env.PRISMA_MANAGEMENT_API_SECRET)
   return gqlQuery({
     url: process.env.PRISMA_URL + '/management',
     token,

--- a/server/scripts/helpers.js
+++ b/server/scripts/helpers.js
@@ -91,14 +91,13 @@ const queryManagement = gql => {
   })
 }
 
-const run = (command, env) => {
-  return execSync(command, {
+const run = (command, env) =>
+  execSync(command, {
     env: {
       ...process.env,
       ...env
     }
   })
-}
 
 module.exports = {
   env,

--- a/server/scripts/helpers.js
+++ b/server/scripts/helpers.js
@@ -92,8 +92,7 @@ const queryManagement = gql => {
 }
 
 const run = (command, env) => {
-  const [executable, ...args] = command.split(' ')
-  return execSync(executable, args, {
+  return execSync(command, {
     env: {
       ...process.env,
       ...env

--- a/server/scripts/prisma_new_service/index.js
+++ b/server/scripts/prisma_new_service/index.js
@@ -36,7 +36,7 @@ const main = async () => {
   }
 
   // Deploy the service
-  await run('prisma deploy', {
+  run('prisma deploy', {
     PRISMA_URL: serviceUrl
   })
 

--- a/server/scripts/prisma_new_service/index.js
+++ b/server/scripts/prisma_new_service/index.js
@@ -1,12 +1,6 @@
 const { env, run, queryManagement, queryService } = require('../helpers')
 
-const {
-  PRISMA_URL,
-  AUTH0_DOMAIN,
-  AUTH0_CLIENT_ID,
-  SERVICE_NAME,
-  SERVICE_STAGE
-} = env([
+const { PRISMA_URL, AUTH0_DOMAIN, AUTH0_CLIENT_ID, SERVICE_NAME, SERVICE_STAGE } = env([
   'PRISMA_URL',
   'PRISMA_API_SECRET', // Implicitely required
   'PRISMA_MANAGEMENT_API_SECRET', // Implicitely required
@@ -67,9 +61,7 @@ const main = async () => {
   )
 
   // Log success
-  console.log(
-    `Successfully deployed a new service (${serviceName}/${serviceStage})!`
-  )
+  console.log(`Successfully deployed a new service (${serviceName}/${serviceStage})!`)
 }
 
 main()

--- a/server/scripts/prisma_new_service/index.js
+++ b/server/scripts/prisma_new_service/index.js
@@ -36,9 +36,11 @@ const main = async () => {
   }
 
   // Deploy the service
-  run('prisma deploy', {
-    PRISMA_URL: serviceUrl
-  })
+  console.log(
+    run('prisma deploy', {
+      PRISMA_URL: serviceUrl
+    })
+  )
 
   // Add a default configuration
   await queryService(


### PR DESCRIPTION
#167 introduced a bug when it switched from execFile to exec without changing up the arguments. execFile takes a file, then command arguments, then options. exec only take 2 arguments: the command and the options. This made scripts ignore the command arguments and options. This did not raise an error because the scripts were running prisma without any argument, so prisma would display the help and exit normally, and the script would assume that everything when fine.