### PR TITLE
:children_crossing: handle errors when retrieving configuration

### DIFF
--- a/server/src/endpoints/configuration.js
+++ b/server/src/endpoints/configuration.js
@@ -1,10 +1,16 @@
 const { getConfiguration } = require('../middlewares/configuration')
 
 const configurationEndpoint = multiTenant => async (req, res) =>
-  getConfiguration(multiTenant, req, () => {
+  getConfiguration(multiTenant, req, err => {
+    res.header('Access-Control-Allow-Origin', '*')
+    
+    if (err) {
+      res.sendStatus(500)
+      return
+    }
+
     const { title, auth0Domain, auth0ClientId, tags } = multiTenant.current(req)._meta.configuration
 
-    res.header('Access-Control-Allow-Origin', '*')
 
     // An unauthenticated user can only access this part of the configuration
     res.json({

--- a/server/src/endpoints/configuration.js
+++ b/server/src/endpoints/configuration.js
@@ -3,14 +3,13 @@ const { getConfiguration } = require('../middlewares/configuration')
 const configurationEndpoint = multiTenant => async (req, res) =>
   getConfiguration(multiTenant, req, err => {
     res.header('Access-Control-Allow-Origin', '*')
-    
+
     if (err) {
       res.sendStatus(500)
       return
     }
 
     const { title, auth0Domain, auth0ClientId, tags } = multiTenant.current(req)._meta.configuration
-
 
     // An unauthenticated user can only access this part of the configuration
     res.json({

--- a/server/src/middlewares/configuration.js
+++ b/server/src/middlewares/configuration.js
@@ -6,8 +6,12 @@ const getConfiguration = async (multiTenant, req, next) => {
     return
   }
 
-  await refreshConfiguration(tenant)
-  next()
+  try {
+    await refreshConfiguration(tenant)
+    next()
+  } catch (err) {
+    next(err)
+  }
 }
 
 const refreshConfiguration = async tenant => {

--- a/server/src/middlewares/configuration.js
+++ b/server/src/middlewares/configuration.js
@@ -6,12 +6,8 @@ const getConfiguration = async (multiTenant, req, next) => {
     return
   }
 
-  try {
-    await refreshConfiguration(tenant)
-    next()
-  } catch (err) {
-    next(err)
-  }
+  await refreshConfiguration(tenant).catch(next)
+  next()
 }
 
 const refreshConfiguration = async tenant => {

--- a/src/services/configuration.js
+++ b/src/services/configuration.js
@@ -21,9 +21,15 @@ class Configuration {
   }
 
   async load() {
-    const configuration = await fetch(process.env.REACT_APP_GRAPHQL_ENDPOINT + '/configuration', {
+    const response = await fetch(process.env.REACT_APP_GRAPHQL_ENDPOINT + '/configuration', {
       headers: { 'prisma-service': routing.getPrismaService() }
-    }).then(res => res.json())
+    })
+    if (!response.ok) {
+      throw new Error(
+        `Error response from server while retrieving configuration: HTTP status ${response.status}`
+      )
+    }
+    const configuration = await response.json()
     this.setData(configuration)
   }
 

--- a/src/services/configuration.js
+++ b/src/services/configuration.js
@@ -58,7 +58,7 @@ class ConfigurationProvider extends Component {
         .catch(err => this.setState({ error: err }))
     } else {
       // Else, load the configuration in the background anyway
-      configuration.load()
+      configuration.load().catch(err => console.warn('Configuration could not be refreshed:', err))
     }
   }
   render() {

--- a/src/services/configuration.js
+++ b/src/services/configuration.js
@@ -39,19 +39,26 @@ class ConfigurationProvider extends Component {
     super(props)
 
     this.state = {
-      loaded: configuration.isLoaded()
+      loaded: configuration.isLoaded(),
+      error: null
     }
   }
   componentDidMount() {
     if (!configuration.isLoaded()) {
       // If no configuration is loaded, load configuration and refresh
-      configuration.load().then(() => this.setState({ loaded: true }))
+      configuration
+        .load()
+        .then(() => this.setState({ loaded: true }))
+        .catch(err => this.setState({ error: err }))
     } else {
       // Else, load the configuration in the background anyway
       configuration.load()
     }
   }
   render() {
+    if (this.state.error) {
+      return <span>Error :(</span>
+    }
     if (!this.state.loaded) {
       return <Loading text="Retrieving configuration..." />
     }


### PR DESCRIPTION
When an error occurred while retrieving configuration, the client would show a infinite loading screen. This change makes a crude error appear instead.

There's an optional refactoring commit in there, you might no want it.